### PR TITLE
Validation Tweaker version 1.0.2

### DIFF
--- a/ValidationTweaker.php
+++ b/ValidationTweaker.php
@@ -254,7 +254,7 @@ $(function()
 {
   var vFields = JSON.parse('<?php echo json_encode($listDateFields); ?>')
   var vNow = new Date()
-  vNow = new Date( vNow.getTime() - ( vNow.getTimezoneOffset() * 60000 ) )
+  vNow = new Date( vNow.getTime() + 900000 - ( vNow.getTimezoneOffset() * 60000 ) )
   vNow = vNow.toISOString().replace( 'T', ' ' )
   Object.keys( vFields ).forEach( function( vFieldName )
   {


### PR DESCRIPTION
This update to the validation tweaker incorporates the following changes:
* Bug fix: Corrected visible field identification for validation enforcement.
* When checking if a date is in the future, validates against *current time + 15 minutes* rather than *current time*. As the current time is calculated at page load, this avoids unnecessary triggering of errors in most cases.